### PR TITLE
Fix pulsarAdminUrl supplied to Kubernetes runtime to correctly handle plaintext/TLS

### DIFF
--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerResourcesFactory.java
@@ -298,8 +298,7 @@ public class FunctionsWorkerResourcesFactory extends BaseResourcesFactory<Functi
                         "pulsarRootDir", "/pulsar",
                         "submittingInsidePod", true,
                         "pulsarServiceUrl", brokerServiceUrl,
-                        "pulsarAdminUrl", "https://%s.%s:6750/"
-                                .formatted(resourceName, getServiceDnsSuffix()),
+                        "pulsarAdminUrl", getFunctionsWorkerServiceUrl(),
                         "percentMemoryPadding", 10)
                 );
                 break;

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerControllerTest.java
@@ -975,7 +975,7 @@ public class FunctionsWorkerControllerTest {
         LinkedHashMap<String, Object> functionRuntimeFactoryConfigs = new LinkedHashMap<>();
         functionRuntimeFactoryConfigs.put("jobNamespace", "ns");
         functionRuntimeFactoryConfigs.put("percentMemoryPadding", 10);
-        functionRuntimeFactoryConfigs.put("pulsarAdminUrl", "https://pul-function.ns.svc.cluster.local:6750/");
+        functionRuntimeFactoryConfigs.put("pulsarAdminUrl", "http://pul-function-ca.ns.svc.cluster.local:6750");
         functionRuntimeFactoryConfigs.put("pulsarDockerImageName", "apachepulsar/pulsar:global");
         functionRuntimeFactoryConfigs.put("pulsarRootDir", "/pulsar");
         functionRuntimeFactoryConfigs.put("pulsarServiceUrl", "pulsar://pul-broker.ns.svc.cluster.local:6650/");


### PR DESCRIPTION
PR to test CI